### PR TITLE
Fixes issue with arbitrary csv headers

### DIFF
--- a/server/tests/utils.test.js
+++ b/server/tests/utils.test.js
@@ -5,6 +5,7 @@ import { hashPublicKeyToNumber } from '../utils'; // Import the function to test
 import { generateAllCards } from '../utils'; // Import the function to test
 import { calculateMaxMarkedInLine } from '../utils'; // Import the function to test
 import { checkLineWin, checkFullCardWin } from '../utils'; // Import the win condition functions
+import { standardizeParticipantObject } from '../utils';
 
 describe('derivePublicKey', () => {
   it('should return the correct public key for a given seed hash and index', () => {
@@ -552,5 +553,11 @@ describe('checkFullCardWin', () => {
     const result = checkFullCardWin(card.grid, drawnNumbersSet);
     // Then: It should return true
     expect(result).toBe(true);
+  });
+
+  it('should standardize the participant object to always have name as the participant name', () => {
+    let participants = [{ 'foo bar': 'baz' }];
+    participants = standardizeParticipantObject(participants);
+    expect(participants[0].name).toBe('baz');
   });
 });

--- a/server/utils.js
+++ b/server/utils.js
@@ -236,10 +236,11 @@ async function getParticipantsFromOpReturn(opReturnHex) {
     let participants = await csvtojson({ 
         output: "json"
     }).fromString(csvData);
-     participants = participants.map((p, i) => ({
-       ...p,
-       ticket: (i + 1).toString() // Add 1-based ticket number
-     }));
+    participants = standardizeParticipantObject(participants);
+    participants = participants.map((p, i) => ({
+      ...p,
+      ticket: (i + 1).toString() // Add 1-based ticket number
+    }));
     console.log(`[Utils] Successfully parsed ${participants.length} participants after handling header.`);
     return participants;
   } catch (ipfsError) {
@@ -247,6 +248,19 @@ async function getParticipantsFromOpReturn(opReturnHex) {
     const errorDetail = ipfsError.response?.status === 404 ? 'File not found at IPFS URL.' : 'Could not fetch or parse CSV file from IPFS.';
     throw new Error(`Failed to retrieve participant list from IPFS: ${errorDetail}`);
   }
+}
+
+/**
+ * Standardizes participant objects to ensure they have a consistent format with a 'name' property.
+ * Takes the first property value from each participant object and assigns it as the name.
+ * 
+ * @param {Array<Object>} participants - Array of participant objects from CSV parsing.
+ * @returns {Array<{name: string}>} Array of standardized participant objects with name property.
+ */
+function standardizeParticipantObject(participants) {
+  return participants.map(participant => ({
+    name: participant[Object.keys(participant)[0]]
+  }));
 }
 
 /**
@@ -555,5 +569,6 @@ module.exports = {
   countMarkedDrawnNumbers,
   calculateMaxMarkedInLine,
   checkLineWin,
-  checkFullCardWin
+  checkFullCardWin,
+  standardizeParticipantObject
 }; 


### PR DESCRIPTION
# Problem

When uploading a csv file with an arbitrary header would make the application not able to retrieve the cards for each player.

Example CSV:
```
My random header
Player 1
Player 2
```

The app expected:
```
name
Player 1
Player 2
```

And then later the app uses the key `name` here https://github.com/eddieoz/bitBingo/blob/master/server/utils.js#L272

# Solution

Introduce a function to standardize the object so participants names are always found in the same property.

This is not the most elegant solution, we could instead just ignore the header and probably have an array of strings instead of a key value map, then later in the code we could just iterate over the array.

Happy to change if @eddieoz recommend